### PR TITLE
Delete $__yeoman_generatorListFile before rewrite

### DIFF
--- a/helpers_yo
+++ b/helpers_yo
@@ -41,6 +41,7 @@ __yo_getLocalGenerators() {
 # @description Store global generators in YEOMAN_PLUGIN_DIR/GENERATOR_LIST.txt
 # @return    void
 __yo_setGlobalGenerators() {
+    [[ -e $__yeoman_generatorListFile ]] && rm -rf $__yeoman_generatorListFile
   npm list --global --parseable --silent \
     | grep '/generator-[^/]*$' \
     | while read line; do __yo_getGeneratorMetadata "$line"; done \


### PR DESCRIPTION
In case the shell has noclobber set, piping to the $__yeoman_generatorListFile
leads to an error. This patch checks and deletes the file before redirecting output.
