### PR TITLE
fix: remove blank lines and header on newer versions of yeoman

### DIFF
--- a/helpers_yo
+++ b/helpers_yo
@@ -59,7 +59,12 @@ __yo_getDescription() {
 }
 
 __yo_get_installed_generators() {
-  command yo --generators | while read line; do __yo_getGeneratorMetadata "$line"; done
+  local REMOVE_TITLE="1"
+  local YO_VERSION=$(yo --version)
+  if [[ "$(printf '%s\n' "$YO_VERSION" "1.6.0" | sort -V | head -n1)" == "1.6.0" ]]; then
+    REMOVE_TITLE="2"
+  fi
+  command yo --generators | tr -s '\n\n' | tr -d ' ' | tail -n +$REMOVE_TITLE | while read line; do __yo_getGeneratorMetadata "$line"; done
 }
 
 # @description Get package name and description from local or global packages:


### PR DESCRIPTION
Fixes #9. Removes blank lines and indentation using `tr` and removes the `Avaliable Generators` header that appears at the top. In action:

![Screenshot from 2022-01-04 17-59-07](https://user-images.githubusercontent.com/53054099/148148716-9e59087e-2d69-4d45-b3e9-de4f0b8754b5.png)
